### PR TITLE
JEXL-309: generate comment lines when replacing verbatims in template…

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -73,6 +73,7 @@ New Features in 3.2:
 Bugs Fixed in 3.2:
 ==================
 
+* JEXL-309:      Line numbers are not correct when template report errors
 * JEXL-306:      Ternary operator ? protects also its branches from resolution errors
 * JEXL-305:      Script debugger produces incorrect syntax
 * JEXL-304:      Error parsing overview.limit.var

--- a/src/main/java/org/apache/commons/jexl3/internal/TemplateEngine.java
+++ b/src/main/java/org/apache/commons/jexl3/internal/TemplateEngine.java
@@ -1077,7 +1077,7 @@ public final class TemplateEngine extends JxltEngine {
         BlockType type = null;
         int prefixLen;
         Iterator<CharSequence> lines = readLines(reader);
-        int lineno = 0;
+        int lineno = 1;
         int start = 0;
         while (lines.hasNext()) {
             CharSequence line = lines.next();

--- a/src/site/xdoc/changes.xml
+++ b/src/site/xdoc/changes.xml
@@ -26,6 +26,9 @@
     </properties>
     <body>
         <release version="3.2" date="unreleased">
+            <action dev="henrib" type="fix" issue="JEXL-309">
+                Line numbers are not correct when template report errors
+            </action>
             <action dev="henrib" type="fix" issue="JEXL-306" due-to="Dmitri Blinov">
                 Ternary operator ? protects also its branches from resolution errors
             </action>

--- a/src/test/java/org/apache/commons/jexl3/Issues300Test.java
+++ b/src/test/java/org/apache/commons/jexl3/Issues300Test.java
@@ -175,4 +175,63 @@ public class Issues300Test {
         o = e.execute(null);
         Assert.assertEquals(2, o);
     }
+    
+    @Test
+    public void testIssue309a() throws Exception {
+        String src = "<html lang=\"en\">\n"
+                + "  <body>\n"
+                + "    <h1>Hello World!</h1>\n"
+                + "$$ var i = 12++;\n"
+                + "  </body>\n"
+                + "</html>";
+        JexlEngine jexl = new JexlBuilder().safe(true).create();
+        JxltEngine jxlt = jexl.createJxltEngine();
+        JexlInfo info = new JexlInfo("template", 1, 1);
+        try {
+            JxltEngine.Template tmplt = jxlt.createTemplate(info, src);
+            Assert.fail("shoud have thrown exception");
+        } catch (JexlException.Parsing xerror) {
+            Assert.assertEquals(4, xerror.getInfo().getLine());
+        }
+    }
+
+    @Test
+    public void testIssue309b() throws Exception {
+        String src = "<html lang=\"en\">\n"
+                + "  <body>\n"
+                + "    <h1>Hello World!</h1>\n"
+                + "$$ var i = a b c;\n"
+                + "  </body>\n"
+                + "</html>";
+        JexlEngine jexl = new JexlBuilder().safe(true).create();
+        JxltEngine jxlt = jexl.createJxltEngine();
+        JexlInfo info = new JexlInfo("template", 1, 1);
+        try {
+            JxltEngine.Template tmplt = jxlt.createTemplate(info, src);
+            Assert.fail("shoud have thrown exception");
+        } catch (JexlException.Parsing xerror) {
+            Assert.assertEquals(4, xerror.getInfo().getLine());
+        }
+    }
+
+    @Test
+    public void testIssue309c() throws Exception {
+        String src = "<html lang=\"en\">\n"
+                + "  <body>\n"
+                + "    <h1>Hello World!</h1>\n"
+                + "$$ var i =12;\n"
+                + "  </body>\n"
+                + "</html>";
+        JexlEngine jexl = new JexlBuilder().safe(true).create();
+        JxltEngine jxlt = jexl.createJxltEngine();
+        JexlInfo info = new JexlInfo("template", 1, 1);
+        try {
+            JxltEngine.Template tmplt = jxlt.createTemplate(info, src);
+            String src1 = tmplt.asString();
+            String src2 = tmplt.toString();
+            Assert.assertEquals(src1, src2);
+        } catch (JexlException.Parsing xerror) {
+            Assert.assertEquals(4, xerror.getInfo().getLine());
+        }
+    }
 }


### PR DESCRIPTION
…s to keep line number in sync

Task #JEXL-309 - Line numbers are not correct when template generate errors