### PR TITLE
JEXL: simplified error reporting, a (proprietary) very long script wi…

### DIFF
--- a/src/main/java/org/apache/commons/jexl3/JexlException.java
+++ b/src/main/java/org/apache/commons/jexl3/JexlException.java
@@ -193,7 +193,7 @@ public class JexlException extends RuntimeException {
      */
     private static JexlInfo merge(JexlInfo info, JavaccError cause) {
         JexlInfo dbgn = info != null ? info : null;
-        if (cause == null) {
+        if (cause == null || cause.getLine() < 0) {
             return dbgn;
         } else if (dbgn == null) {
             return new JexlInfo("", cause.getLine(), cause.getColumn());

--- a/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
+++ b/src/main/java/org/apache/commons/jexl3/parser/Parser.jjt
@@ -26,6 +26,8 @@ options
    UNICODE_INPUT=true;
    KEEP_LINE_COLUMN=true;
    TRACK_TOKENS=true;
+   CACHE_TOKENS=true;
+   ERROR_REPORTING=false;
    //DEBUG_PARSER=true;
    //DEBUG_TOKEN_MANAGER=true;
 }
@@ -67,7 +69,8 @@ public final class Parser extends JexlParser
         } catch (TokenMgrError xtme) {
             throw new JexlException.Tokenization(info, xtme).clean();
         } catch (ParseException xparse) {
-            throw new JexlException.Parsing(info, xparse).clean();
+            Token errortok = token.next;
+            throw new JexlException.Parsing(info.at(errortok.beginLine, errortok.beginColumn), token.image).clean();
         } finally {
             token_source.defaultLexState = DEFAULT;
             cleanup(previous);
@@ -346,7 +349,7 @@ void Statement() #void : {}
     | Continue()
     | Break()
     | Var()
-    | Pragma()
+    | Pragma() 
 }
 
 void Block() #Block : {}

--- a/src/test/java/org/apache/commons/jexl3/LexicalTest.java
+++ b/src/test/java/org/apache/commons/jexl3/LexicalTest.java
@@ -486,7 +486,11 @@ public class LexicalTest {
         JexlFeatures f = new JexlFeatures();
         f.lexical(true);
         JexlEngine jexl = new JexlBuilder().strict(true).features(f).create();
-        JexlScript script = jexl.createScript("var x = 32; (()->{ for(var x : null) { var c = 0; {return x; }} })();");
+        JexlScript script = jexl.createScript(
+                "var x = 32; ("
+                        + "()->{ for(var x : null) { var c = 0; {return x; }} })"
+                        + "();");
+        Assert.assertNull(script.execute(null));
     }
     
     @Test
@@ -507,8 +511,7 @@ public class LexicalTest {
            // OK
         }
     }
-    
-            
+           
     @Test
     public void testForVariable1() throws Exception {
         JexlFeatures f = new JexlFeatures();


### PR DESCRIPTION
…th a syntax error was taking >10' to check; culprit was a jj_rescan_ that got... lost.